### PR TITLE
Unable to get hash for file attachments.

### DIFF
--- a/src/main/java/kenichia/quipapi/QuipBlob.java
+++ b/src/main/java/kenichia/quipapi/QuipBlob.java
@@ -29,11 +29,12 @@ public class QuipBlob extends QuipJsonObject {
 
     /**
      * Method to get images and attachments from a thread or thread messages.
+     *
      * @param threadId - thread id.
-     * @param blobId - id of the blob to be fetched.
+     * @param blobId   - id of the blob to be fetched.
      * @return - byte[] of the blob
      * @throws Exception - if the blob not exit on the thread or if the
-     * thread id is invalid.
+     *                   thread id is invalid.
      */
     public static byte[] getBlob(String threadId, String blobId) throws Exception {
         return _getToByteArray(

--- a/src/main/java/kenichia/quipapi/QuipMessage.java
+++ b/src/main/java/kenichia/quipapi/QuipMessage.java
@@ -92,6 +92,18 @@ public class QuipMessage extends QuipJsonObject {
   }
 
   /**
+   * Gets an array of files with name and hash as JsonArray
+   * @return String "[{"name":"xxxxx","hash":"xxxx"}]"
+   */
+  public String getFilesWithHashAsString() {
+    JsonArray arr = _getJsonArray("files");
+    if (arr == null) {
+      return null;
+    }
+    return arr.toString();
+  }
+
+  /**
    * Gets an array of files with name and hash
    * @return String[] [{"name":"xxxxx","hash":"xxxx"}]
    */

--- a/src/main/java/kenichia/quipapi/QuipMessage.java
+++ b/src/main/java/kenichia/quipapi/QuipMessage.java
@@ -176,9 +176,9 @@ public class QuipMessage extends QuipJsonObject {
         params.add(new BasicNameValuePair("sorted_by", sortedBy.name()));
     }
 
-    if (messageType != null)
-      params.add(
-              new BasicNameValuePair("message_type", messageType.name()));
+    if (messageType != null) {
+      params.add(new BasicNameValuePair("message_type", messageType.name().toLowerCase()));
+    }
     JsonArray arr = _getToJsonArray(
             new URIBuilder(QuipAccess.ENDPOINT + "/messages/" + threadId)
                     .addParameters(params).build());

--- a/src/main/java/kenichia/quipapi/QuipMessage.java
+++ b/src/main/java/kenichia/quipapi/QuipMessage.java
@@ -91,6 +91,27 @@ public class QuipMessage extends QuipJsonObject {
         .toArray(String[]::new);
   }
 
+  /**
+   * Gets an array of files with name and hash
+   * @return String[] [{"name":"xxxxx","hash":"xxxx"}]
+   */
+  public String[] getFilesWithHash() {
+      JsonArray arr = _getJsonArray("files");
+      if (arr == null) {
+          return null;
+      }
+      return StreamSupport.stream(arr.spliterator(), false)
+            .map(e -> {
+              JsonObject file = e.getAsJsonObject();
+              if(Objects.nonNull(file)){
+                return file.toString();
+              }
+              return null;
+            }).filter(Objects::nonNull)
+            .toArray(String[]::new);
+  }
+
+
   public QuipDiffGroup[] getDiffGroups() {
     JsonArray arr = _getJsonArray("diff_groups");
     if (arr == null)


### PR DESCRIPTION
When retrieving we are only able to get the file names of attachments. But the hash is required when we need to extract the attachment.