### PR TITLE
Add QuipThread.Type.SLIDES

### DIFF
--- a/src/main/java/kenichia/quipapi/QuipThread.java
+++ b/src/main/java/kenichia/quipapi/QuipThread.java
@@ -43,7 +43,7 @@ public class QuipThread extends QuipJsonObject {
     // ============================================
 
     public enum Type {
-        DOCUMENT("document"), SPREADSHEET("spreadsheet"), CHAT("chat");
+        DOCUMENT("document"), SPREADSHEET("spreadsheet"), CHAT("chat"), SLIDES("slides");
 
         private final String _value;
 


### PR DESCRIPTION
Quip has 4 types for a thread - Document, Spreadsheet, Chat and **Slides**.

The code didn't have support for Slides, which led to `(QuipThread q).type == null` for slides, because there was no enum for the value `"slides"`. Adding this enum resolves the problem.

Link to `Get Thread` method documentation, where you can see all 4 possible values for the Type enum: https://quip.com/dev/automation/documentation/current#operation/getThreadV2