### PR TITLE
Add QuipFolder.getLink() property

### DIFF
--- a/src/main/java/kenichia/quipapi/QuipFolder.java
+++ b/src/main/java/kenichia/quipapi/QuipFolder.java
@@ -106,6 +106,10 @@ public class QuipFolder extends QuipJsonObject {
         return _getString("folder", "title");
     }
 
+    public String getLink() {
+        return _getString("folder", "link");
+    }
+
     public Instant getCreatedUsec() {
         return _getInstant("folder", "created_usec");
     }


### PR DESCRIPTION
This property exists on QuipFolder, documentation https://quip.com/dev/automation/documentation/current#operation/getFolder